### PR TITLE
fix: resolve label strike-through issue on form. #9

### DIFF
--- a/client/src/components/OpenSavingAccount.js
+++ b/client/src/components/OpenSavingAccount.js
@@ -96,6 +96,7 @@ const AccountForm = () => {
             <Select
               name="gender"
               value={formData.gender}
+              label="Gender"
               onChange={handleChange}
               
             >
@@ -112,6 +113,7 @@ const AccountForm = () => {
             <Select
               name="accountType"
               value={formData.accountType}
+              label="Account Type"
               onChange={handleChange}
         
             >


### PR DESCRIPTION
fix: resolve label strike-through issue on form outline for 'Gender' and 'Account Type' fields
#9